### PR TITLE
Add patch for Xtensa VaListImpl

### DIFF
--- a/0005-Teach-rust-core-about-Xtensa-VaListImpl.patch
+++ b/0005-Teach-rust-core-about-Xtensa-VaListImpl.patch
@@ -1,0 +1,96 @@
+From 3bbc92423ca602ad9441b83e8701c9bc42834f4f Mon Sep 17 00:00:00 2001
+From: "Brian J. Tarricone" <brian@tarricone.org>
+Date: Mon, 15 Feb 2021 23:32:16 -0800
+Subject: [PATCH] Teach rust core about Xtensa VaListImpl
+
+---
+ library/core/src/ffi.rs | 31 +++++++++++++++++++++++++------
+ 1 file changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/library/core/src/ffi.rs b/library/core/src/ffi.rs
+index 4b303acfd3b..ff9ce5998ca 100644
+--- a/library/core/src/ffi.rs
++++ b/library/core/src/ffi.rs
+@@ -61,7 +61,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+ /// Basic implementation of a `va_list`.
+ // The name is WIP, using `VaListImpl` for now.
+ #[cfg(any(
+-    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
++    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64"), not(target_arch = "xtensa")),
+     all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
+     target_arch = "wasm32",
+     target_arch = "asmjs",
+@@ -84,7 +84,7 @@ pub struct VaListImpl<'f> {
+ }
+ 
+ #[cfg(any(
+-    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
++    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64"), not(target_arch = "xtensa")),
+     all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
+     target_arch = "wasm32",
+     target_arch = "asmjs",
+@@ -169,6 +169,24 @@ pub struct VaListImpl<'f> {
+     _marker: PhantomData<&'f mut &'f c_void>,
+ }
+ 
++/// xtensa ABI implementation of a `va_list`.
++#[cfg(target_arch = "xtensa")]
++#[repr(C)]
++#[derive(Debug)]
++#[unstable(
++    feature = "c_variadic",
++    reason = "the `c_variadic` feature has not been properly tested on \
++              all supported platforms",
++    issue = "44930"
++)]
++#[lang = "va_list"]
++pub struct VaListImpl<'f> {
++    stk: *mut i32,
++    reg: *mut i32,
++    ndx: i32,
++    _marker: PhantomData<&'f mut &'f i32>,
++}
++
+ /// A wrapper for a `va_list`
+ #[repr(transparent)]
+ #[derive(Debug)]
+@@ -183,7 +201,8 @@ pub struct VaList<'a, 'f: 'a> {
+         all(
+             not(target_arch = "aarch64"),
+             not(target_arch = "powerpc"),
+-            not(target_arch = "x86_64")
++            not(target_arch = "x86_64"),
++            not(target_arch = "xtensa")
+         ),
+         all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
+         target_arch = "wasm32",
+@@ -193,7 +212,7 @@ pub struct VaList<'a, 'f: 'a> {
+     inner: VaListImpl<'f>,
+ 
+     #[cfg(all(
+-        any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
++        any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64", target_arch = "xtensa"),
+         any(not(target_arch = "aarch64"), not(any(target_os = "macos", target_os = "ios"))),
+         not(target_arch = "wasm32"),
+         not(target_arch = "asmjs"),
+@@ -205,7 +224,7 @@ pub struct VaList<'a, 'f: 'a> {
+ }
+ 
+ #[cfg(any(
+-    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
++    all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64"), not(target_arch = "xtensa")),
+     all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
+     target_arch = "wasm32",
+     target_arch = "asmjs",
+@@ -226,7 +245,7 @@ pub fn as_va_list<'a>(&'a mut self) -> VaList<'a, 'f> {
+ }
+ 
+ #[cfg(all(
+-    any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
++    any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64", target_arch = "xtensa"),
+     any(not(target_arch = "aarch64"), not(any(target_os = "macos", target_os = "ios"))),
+     not(target_arch = "wasm32"),
+     not(target_arch = "asmjs"),
+-- 
+2.30.0
+


### PR DESCRIPTION
Pulled from this comment in LLVM's `XtensaISelLowering.cpp`:
```
  // typedef struct __va_list_tag {
  //   int32_t *__va_stk; /* Initialized to point  to the position of the
  //                       * first argument in memory offset to account for
  //                       the
  //                       * arguments passed in registers and to account for
  //                       * the size of the argument registers not being
  //                       16-byte
  //                       * aligned.  E.G., there are 6 argument registers
  //                       * of 4 bytes each, but we want the __va_ndx for the
  //                       * first stack argument to have the maximal
  //                       * alignment of 16 bytes, so we offset the __va_stk
  //                       address by
  //                       * 32 bytes so that __va_stk[32] references the
  //                       first
  //                       * argument on the stack.
  //                       */
  //   int32_t  *__va_reg; /* Points to a stack-allocated region holding the
  //                        * contents
  //                        * of the incoming argument registers
  //                        */
  //   int32_t __va_ndx;   /* Index initialized to the position of the first
  //                        * unnamed (variable) argument.  This same index is
  //                        also
  //                        * used to address the arguments passed in memory.
  //                       */
  //  } __va_list_tag[1];
```

This doesn't yet seem to actually _work_... that is, the ESP32 throws a `LoadProhibited` CPU exception when I try to use it.  It's possible LLVM's va_list codegen is buggy (rustc should be using the LLVM fallback for xtensa, as I didn't touch that code in rustc), or maybe there's more that's necessary here that I don't quite understand, like perhaps the Xtensa ABI call patch needs to be modified too.

Anyhow, this applies cleanly to rust 1.50.0, but I think it should work for 1.49.0 as well.